### PR TITLE
[#65] Remove duplicate rows in table for manual complexity calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,7 @@ Out of these, the following five methods were chosen for manual complexity calcu
 |                    17 |  68 | SessionResultsData::buildSingleResponseForStudent                                | Markus: 17, Edvin: 17          |
 |                    17 |  52 | FeedbackResponseCommentsLogic::isFeedbackParticipantNameVisibleToUser            | Markus: 17, Linnéa: 17         |
 |                    16 |  82 | FeedbackRankRecipientsResponseDetails::getUpdateOptionsForRankRecipientQuestions | Peter: 16, Linnéa: 16          |
-|                    15 |  50 | SessionResultsData::initForStudent                                               |                                |
-|                    16 |  82 | FeedbackRankRecipientsResponseDetails::getUpdateOptionsForRankRecipientQuestions |                                |
 |                    15 |  50 | SessionResultsData::initForStudent                                               | Edvin: 15, Samuel: 16          |
-|                    15 |  41 | FeedbackMsqQuestionDetails::shouldChangesRequireResponseDeletion                 |                                |
-|                    15 |  50 | SessionResultsData::initForStudent                                               |                                |
 |                    15 |  41 | FeedbackMsqQuestionDetails::shouldChangesRequireResponseDeletion                 | Samuel: 15, Peter: 15          |
 
 


### PR DESCRIPTION
Fixes #65

Fix: Remove duplicate rows in table for manual complexity calculations